### PR TITLE
Add OpenHands PR tracking

### DIFF
--- a/backend/aitw/scrape/pr_classifier.py
+++ b/backend/aitw/scrape/pr_classifier.py
@@ -29,6 +29,8 @@ class PrClassifier:
                 pr.agent = 'jules'
             if 'claude[bot]' in first_commit_first_authors:
                 pr.agent = 'claude'
+            if 'openhands-agent' in first_commit_first_authors:
+                pr.agent = 'openhands'
                 
         if pr.agent is None and pr.actor and pr.actor.type == 'Bot':
             pr.agent = "bot"


### PR DESCRIPTION
This PR adds tracking for [OpenHands](https://github.com/All-Hands-AI/OpenHands) PRs in the PR classifier.

The implementation checks if 'openhands-agent' is in the list of authors for the first commit of a PR, and if so, sets the PR's agent to 'openhands'.

This follows the same pattern as the existing code for other agents like 'jules' and 'claude'.

The current PR is an example of OpenHands' PR :)